### PR TITLE
Fix: Properly unwrap ssl_ctx optional pointer in acceptIncomingConnections

### DIFF
--- a/modules/core/server_ops.zig
+++ b/modules/core/server_ops.zig
@@ -22,8 +22,8 @@ pub fn acceptIncomingConnections(
             return err;
         };
         const fd = conn.stream.handle;
-        if (ssl_ctx) |_| {
-            ssl_ops.acceptSSL(fd, epoll, ssl_ctx, connection) catch |err| {
+        if (ssl_ctx) |ctx| {
+            ssl_ops.acceptSSL(fd, epoll, ctx, connection) catch |err| {
                 if (err == error.SSLHandshakeFailed or err == error.FailedToCreateSSLObject) {
                     try sendBadRequest(.{ .fd = conn.stream.handle, .ssl = null });
                     _ = std.posix.close(fd);


### PR DESCRIPTION
## Bug Description

The `ssl_ctx` parameter in `acceptIncomingConnections` is an optional pointer (`?*ssl_ops.SSL_CTX`). When the code checks if it's not null and passes it to `ssl_ops.acceptSSL()`, it passes the optional itself rather than the unwrapped pointer value.

## Root Cause

```zig
if (ssl_ctx) |_| {
    ssl_ops.acceptSSL(fd, epoll, ssl_ctx, connection)  // ssl_ctx is still ?*ssl_ops.SSL_CTX
```

The `ssl_ops.acceptSSL()` function expects a non-optional `*ssl_ops.SSL_CTX`, but receives `?*ssl_ops.SSL_CTX`.

## Fix

Capture the unwrapped value in the if statement:

```zig
if (ssl_ctx) |ctx| {
    ssl_ops.acceptSSL(fd, epoll, ctx, connection)  // ctx is now *ssl_ops.SSL_CTX
```

## Impact

- **Severity**: Moderate - causes crash when SSL is enabled
- **Confidence**: High - clear type mismatch in Zig's type system

## Testing

This fix should be verified by:
1. Enabling SSL in the server configuration
2. Making HTTPS requests to ensure SSL handshake completes without crash
3. Verifying that HTTP requests still work when SSL is disabled

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.